### PR TITLE
map-stream example: wrap map() call in a function

### DIFF
--- a/_generator/src/tour-of-node-build-tools-gulp-3.md
+++ b/_generator/src/tour-of-node-build-tools-gulp-3.md
@@ -61,12 +61,14 @@ var map  = require('map-stream');
 
 gulp.task('replace', function() {
     return gulp.src('src/**/*.js')
-        .pipe(map(function (file, cb) {
-            var contents = file.contents.toString('utf8');
-            contents = contents.replace(/abc/g, '123');
-            file.contents = new Buffer(contents, 'utf8');
-            cb(null, file);
-        }));
+        .pipe(function() { 
+            return map(function (file, cb) {
+                var contents = file.contents.toString('utf8');
+                contents = contents.replace(/abc/g, '123');
+                file.contents = new Buffer(contents, 'utf8');
+                cb(null, file);
+            });
+        });
 });
 ```
 


### PR DESCRIPTION
gulp `pipe()` requires a function that returns a Stream. `map()` returns a Stream object, not a function. So all I needed to do to get the map-stream example to work was to wrap the call to `map()` in a function.
